### PR TITLE
Add fall back to `getrandom` for Linux/Android

### DIFF
--- a/secure-random/src/commonMain/kotlin/io/matthewnelson/secure/random/SecureRandom.kt
+++ b/secure-random/src/commonMain/kotlin/io/matthewnelson/secure/random/SecureRandom.kt
@@ -25,7 +25,7 @@ public expect class SecureRandom() {
      * securely generated random data.
      *
      * @throws [IllegalArgumentException] if [count] is negative.
-     * @throws [SecRandomCopyException] if [nextBytesCopyTo] failed
+     * @throws [SecRandomCopyException] if [nextBytesCopyTo] failed.
      * */
     @Throws(IllegalArgumentException::class, SecRandomCopyException::class)
     public fun nextBytesOf(count: Int): ByteArray
@@ -34,7 +34,7 @@ public expect class SecureRandom() {
      * Fills a [ByteArray] with securely generated random data.
      * Does nothing if [bytes] is null or empty.
      *
-     * @throws [SecRandomCopyException] if procurement of securely random data failed
+     * @throws [SecRandomCopyException] if procurement of securely random data failed.
      * */
     @Throws(SecRandomCopyException::class)
     public fun nextBytesCopyTo(bytes: ByteArray?)

--- a/secure-random/src/commonTest/kotlin/io/matthewnelson/secure/random/EnsureFilledHelper.kt
+++ b/secure-random/src/commonTest/kotlin/io/matthewnelson/secure/random/EnsureFilledHelper.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.secure.random
+
+import kotlin.test.assertTrue
+
+/**
+ * Test helper to extend for some platforms which have fallback
+ * implementations if something is not available.
+ * */
+abstract class EnsureFilledHelper {
+
+    protected abstract val sRandom: SecureRandom
+
+    // https://github.com/briansmith/ring/blob/main/tests/rand_tests.rs
+    open fun givenByteArray_whenNextBytes_thenIsFilledWithData() {
+        val linuxLimit = 256
+        val webLimit = 65536
+
+        val sizes = listOf(
+            1,
+            2,
+            3,
+            96,
+            linuxLimit - 1,
+            linuxLimit,
+            linuxLimit + 1,
+            linuxLimit * 2,
+            511,
+            512,
+            513,
+            4096,
+            webLimit - 1,
+            webLimit,
+            webLimit + 1,
+            webLimit * 2,
+        )
+
+        for (size in sizes) {
+            val bytes = ByteArray(size)
+            val emptyByte = bytes[0]
+
+            sRandom.nextBytesCopyTo(bytes)
+
+            var emptyCount = 0
+            bytes.forEach {
+                if (it == emptyByte) {
+                    emptyCount++
+                }
+            }
+
+            // Some indices will remain empty so cannot check if all were
+            // filled. Must adjust our limit depending on size to mitigate
+            // false positives.
+            val emptyLimit = when {
+                size < 10 -> 0.5f
+                size < 200 -> 0.04F
+                size < 1000 -> 0.03F
+                size < 10000 -> 0.01F
+                else -> 0.0075F
+            }.let { pctErr ->
+                (size * pctErr).toInt()
+            }
+
+            val message = "size=$size,emptyLimit=$emptyLimit,emptyCount=$emptyCount"
+//            println(message)
+
+            assertTrue(
+                actual = emptyCount <= emptyLimit,
+                message = message
+            )
+        }
+    }
+}

--- a/secure-random/src/commonTest/kotlin/io/matthewnelson/secure/random/SecureRandomUnitTest.kt
+++ b/secure-random/src/commonTest/kotlin/io/matthewnelson/secure/random/SecureRandomUnitTest.kt
@@ -19,12 +19,14 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
-class SecureRandomUnitTest {
+class SecureRandomUnitTest: EnsureFilledHelper() {
+
+    override val sRandom = SecureRandom()
 
     @Test
     fun givenNextBytesOf_whenCountNegative_thenThrows() {
         try {
-            SecureRandom().nextBytesOf(-1)
+            sRandom.nextBytesOf(-1)
             fail()
         } catch (_: IllegalArgumentException) {
             // pass
@@ -33,75 +35,11 @@ class SecureRandomUnitTest {
 
     @Test
     fun givenNextBytesOf_whenCount0_thenReturnsEmpty() {
-        assertTrue(SecureRandom().nextBytesOf(0).isEmpty())
+        assertTrue(sRandom.nextBytesOf(0).isEmpty())
     }
 
-    // https://github.com/briansmith/ring/blob/main/tests/rand_tests.rs
     @Test
-    fun givenByteArray_whenNextBytes_thenIsFilledWithData() {
-        val linuxLimit = 256
-        val webLimit = 65536
-
-        val sizes = listOf(
-            1,
-            2,
-            3,
-            96,
-            linuxLimit - 1,
-            linuxLimit,
-            linuxLimit + 1,
-            linuxLimit * 2,
-            511,
-            512,
-            513,
-            4096,
-            webLimit - 1,
-            webLimit,
-            webLimit + 1,
-            webLimit * 2,
-        )
-
-        val sRandom = SecureRandom()
-
-        for (size in sizes) {
-            val bytes = ByteArray(size)
-            val emptyByte = bytes[0]
-
-            try {
-                sRandom.nextBytesCopyTo(bytes)
-            } catch (e: SecRandomCopyException) {
-                // TODO: Remove once implementations are all complete
-                if (e.message == "SYS_getrandom not supported") {
-                    continue
-                } else {
-                    throw e
-                }
-            }
-
-            var emptyCount = 0
-            bytes.forEach {
-                if (it == emptyByte) {
-                    emptyCount++
-                }
-            }
-
-            // Some indices will remain empty so cannot check if all were
-            // filled. Must adjust our limit depending on size to mitigate
-            // false positives.
-            val emptyLimit = when {
-                size < 10 -> 0.5f
-                size < 200 -> 0.04F
-                size < 1000 -> 0.03F
-                size < 10000 -> 0.01F
-                else -> 0.0075F
-            }.let { pctErr ->
-                (size * pctErr).toInt()
-            }
-
-            assertTrue(
-                actual = emptyCount <= emptyLimit,
-                message = "size=$size,emptyLimit=$emptyLimit,emptyCount=$emptyCount"
-            )
-        }
+    override fun givenByteArray_whenNextBytes_thenIsFilledWithData() {
+        super.givenByteArray_whenNextBytes_thenIsFilledWithData()
     }
 }

--- a/secure-random/src/darwinMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/darwinMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("UnnecessaryOptInAnnotation")
+
 package io.matthewnelson.secure.random.internal
 
 import io.matthewnelson.secure.random.SecRandomCopyException

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/GetRandom.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/GetRandom.kt
@@ -17,15 +17,12 @@
 
 package io.matthewnelson.secure.random.internal
 
+import io.matthewnelson.secure.random.SecRandomCopyException
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.UnsafeNumber
 import kotlinx.cinterop.convert
-import platform.posix.ENOSYS
-import platform.posix.EPERM
-import platform.posix.size_t
-import platform.posix.syscall
-import platform.posix.u_int
+import platform.posix.*
 
 /**
  * Helper for:
@@ -53,7 +50,6 @@ internal class GetRandom private constructor(): SecRandomPoller() {
         return pollingResult { buf, size ->
             @OptIn(UnsafeNumber::class)
             val result = getrandom(buf, size.toULong().convert(), GRND_NONBLOCK)
-
             if (result < 0) {
                 when (result) {
                     ENOSYS, // No kernel support
@@ -72,7 +68,11 @@ internal class GetRandom private constructor(): SecRandomPoller() {
      * Must always call [isAvailable] beforehand.
      * */
     @OptIn(UnsafeNumber::class)
-    internal fun getrandom(buf: CPointer<ByteVar>, buflen: size_t): Int = getrandom(buf, buflen, NO_FLAGS)
+    @Throws(SecRandomCopyException::class)
+    internal fun getrandom(buf: CPointer<ByteVar>, buflen: Int) {
+        val result = getrandom(buf, buflen.toULong().convert(), NO_FLAGS)
+        if (result < 0) throw SecRandomCopyException(errnoToString(result))
+    }
 
     @OptIn(UnsafeNumber::class)
     private fun getrandom(
@@ -80,7 +80,6 @@ internal class GetRandom private constructor(): SecRandomPoller() {
         buflen: size_t,
         flags: u_int,
     ): Int {
-        @Suppress("RemoveRedundantCallsOfConversionMethods")
-        return syscall(SYS_getrandom.convert(), buf, buflen, flags).toInt()
+        return syscall(SYS_getrandom.convert(), buf, buflen, flags).convert()
     }
 }

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/GetRandom.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/GetRandom.kt
@@ -51,7 +51,7 @@ internal class GetRandom private constructor(): SecRandomPoller() {
             @OptIn(UnsafeNumber::class)
             val result = getrandom(buf, size.toULong().convert(), GRND_NONBLOCK)
             if (result < 0) {
-                when (result) {
+                when (errno) {
                     ENOSYS, // No kernel support
                     EPERM, // Blocked by seccomp
                     -> false
@@ -71,7 +71,7 @@ internal class GetRandom private constructor(): SecRandomPoller() {
     @Throws(SecRandomCopyException::class)
     internal fun getrandom(buf: CPointer<ByteVar>, buflen: Int) {
         val result = getrandom(buf, buflen.toULong().convert(), NO_FLAGS)
-        if (result < 0) throw SecRandomCopyException(errnoToString(result))
+        if (result < 0) throw SecRandomCopyException(errnoToString(errno))
     }
 
     @OptIn(UnsafeNumber::class)

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/GetRandom.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/GetRandom.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("SpellCheckingInspection", "UnnecessaryOptInAnnotation")
+
 package io.matthewnelson.secure.random.internal
 
 import kotlinx.cinterop.ByteVar

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
@@ -43,12 +43,11 @@ internal actual abstract class SecRandomDelegate private actual constructor() {
         }
     }
 
-    // TODO: Add fallback (Issue #25)
-    private object SecRandomDelegateURandom: SecRandomDelegate() {
+    internal object SecRandomDelegateURandom: SecRandomDelegate() {
 
         @Throws(SecRandomCopyException::class)
         override fun nextBytesCopyTo(size: Int, ptrBytes: CPointer<ByteVar>) {
-            throw SecRandomCopyException("SYS_getrandom not supported")
+            URandom.instance.readBytesTo(ptrBytes, size)
         }
     }
 }

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
@@ -13,15 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress("UnnecessaryOptInAnnotation")
-
 package io.matthewnelson.secure.random.internal
 
 import io.matthewnelson.secure.random.SecRandomCopyException
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.CPointer
-import kotlinx.cinterop.UnsafeNumber
-import kotlinx.cinterop.convert
 
 internal actual abstract class SecRandomDelegate private actual constructor() {
 
@@ -43,11 +39,7 @@ internal actual abstract class SecRandomDelegate private actual constructor() {
 
         @Throws(SecRandomCopyException::class)
         override fun nextBytesCopyTo(size: Int, ptrBytes: CPointer<ByteVar>) {
-            @OptIn(UnsafeNumber::class)
-            val result = GetRandom.instance.getrandom(ptrBytes, size.toULong().convert())
-            if (result < 0) {
-                throw SecRandomCopyException(errnoToString(result))
-            }
+            GetRandom.instance.getrandom(ptrBytes, size)
         }
     }
 

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("UnnecessaryOptInAnnotation")
+
 package io.matthewnelson.secure.random.internal
 
 import io.matthewnelson.secure.random.SecRandomCopyException

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/URandom.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/URandom.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("SpellCheckingInspection", "UnnecessaryOptInAnnotation")
+
+package io.matthewnelson.secure.random.internal
+
+import io.matthewnelson.secure.random.SecRandomCopyException
+import kotlinx.cinterop.*
+import platform.posix.*
+import kotlin.native.concurrent.AtomicInt
+
+internal class URandom private constructor(): SecRandomPoller() {
+
+    internal companion object {
+        private const val INFINITE_TIMEOUT = -1
+
+        internal val instance = URandom()
+    }
+
+    private val lock = Lock()
+
+    @Throws(SecRandomCopyException::class)
+    internal fun readBytesTo(buf: CPointer<ByteVar>, buflen: Int) {
+        ensureSeeded()
+        lock.withLock {
+            @OptIn(UnsafeNumber::class)
+            withReadOnlyFD("/dev/urandom") { fd ->
+                val result = read(fd, buf, buflen.toULong().convert())
+                if (result < 0) throw SecRandomCopyException(errnoToString(errno))
+            }
+        }
+    }
+
+    /**
+     * Poll /dev/random once and only once to ensure
+     * /dev/urandom is seeded and ready to use.
+     * */
+    private fun ensureSeeded() {
+        pollingResult { _, _ ->
+            withReadOnlyFD("/dev/random") { fd ->
+                memScoped {
+                    val pollFd = nativeHeap.alloc<pollfd>()
+                    pollFd.apply {
+                        this.fd = fd
+                        events = POLLIN.convert()
+                        revents = 0
+                    }
+
+                    while (true) {
+                        @OptIn(UnsafeNumber::class)
+                        val result = poll(pollFd.ptr, 1, INFINITE_TIMEOUT)
+                        if (result >= 0) {
+                            break
+                        }
+                        when (val err = errno) {
+                            EINTR,
+                            EAGAIN -> continue
+                            else -> throw SecRandomCopyException(errnoToString(err))
+                        }
+                    }
+                }
+            }
+
+            true
+        }
+    }
+
+    private fun withReadOnlyFD(path: String, block: (fd: Int) -> Unit) {
+        val fd = open(path, O_RDONLY, null)
+        if (fd == -1) throw SecRandomCopyException(errnoToString(errno))
+
+        try {
+            block.invoke(fd)
+        } finally {
+            close(fd)
+        }
+    }
+
+    private inner class Lock {
+
+        // 0: Unlocked
+        // *: Locked
+        private val lock = AtomicInt(0)
+
+        fun <T> withLock(block: () -> T): T {
+            val lockId = Any().hashCode()
+
+            try {
+                while (true) {
+                    if (lock.compareAndSet(0, lockId)) {
+                        break
+                    }
+                }
+
+                return block.invoke()
+            } finally {
+                lock.compareAndSet(lockId, 0)
+            }
+        }
+    }
+}

--- a/secure-random/src/linuxAndroidTest/kotlin/io/matthewnelson/secure/random/internal/URandomUnitTest.kt
+++ b/secure-random/src/linuxAndroidTest/kotlin/io/matthewnelson/secure/random/internal/URandomUnitTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.secure.random.internal
+
+import io.matthewnelson.secure.random.EnsureFilledHelper
+import io.matthewnelson.secure.random.SecureRandom
+import kotlin.test.Test
+
+class URandomUnitTest: EnsureFilledHelper() {
+
+    override val sRandom: SecureRandom = SecureRandom(SecRandomDelegate.SecRandomDelegateURandom)
+
+    @Test
+    override fun givenByteArray_whenNextBytes_thenIsFilledWithData() {
+        if (!GetRandom.instance.isAvailable()) {
+            // commonTest will fall back to use URandom, and we
+            // do not need to double test it here.
+            return
+        }
+
+        super.givenByteArray_whenNextBytes_thenIsFilledWithData()
+    }
+}

--- a/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/SecureRandom.kt
+++ b/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/SecureRandom.kt
@@ -33,7 +33,7 @@ public actual class SecureRandom public actual constructor() {
      * securely generated random data.
      *
      * @throws [IllegalArgumentException] if [count] is negative.
-     * @throws [SecRandomCopyException] if [nextBytesCopyTo] failed
+     * @throws [SecRandomCopyException] if [nextBytesCopyTo] failed.
      * */
     @Throws(IllegalArgumentException::class, SecRandomCopyException::class)
     public actual fun nextBytesOf(count: Int): ByteArray = commonNextBytesOf(count)
@@ -42,7 +42,7 @@ public actual class SecureRandom public actual constructor() {
      * Fills a [ByteArray] with securely generated random data.
      * Does nothing if [bytes] is null or empty.
      *
-     * @throws [SecRandomCopyException] if procurement of securely random data failed
+     * @throws [SecRandomCopyException] if procurement of securely random data failed.
      * */
     @Throws(SecRandomCopyException::class)
     public actual fun nextBytesCopyTo(bytes: ByteArray?) {

--- a/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/SecureRandom.kt
+++ b/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/SecureRandom.kt
@@ -24,9 +24,13 @@ import kotlinx.cinterop.usePinned
 /**
  * A cryptographically strong random number generator (RNG).
  * */
-public actual class SecureRandom public actual constructor() {
+public actual class SecureRandom {
 
-    private val nativeDelegate: SecRandomDelegate = SecRandomDelegate.instance()
+    private val delegate: SecRandomDelegate
+
+    public actual constructor(): this(SecRandomDelegate.instance())
+    internal constructor(delegate: SecRandomDelegate) { this.delegate = delegate }
+
 
     /**
      * Returns a [ByteArray] of size [count], filled with
@@ -49,7 +53,7 @@ public actual class SecureRandom public actual constructor() {
         bytes.ifNotNullOrEmpty {
             usePinned { pinned ->
                 memScoped {
-                    nativeDelegate.nextBytesCopyTo(size, pinned.addressOf(0))
+                    delegate.nextBytesCopyTo(size, pinned.addressOf(0))
                 }
             }
         }

--- a/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/internal/-Cinterop.kt
+++ b/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/internal/-Cinterop.kt
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  **/
 package io.matthewnelson.secure.random.internal
 


### PR DESCRIPTION
Closes #25 

Adds ability to read from `/dev/urandom` if `getrandom` is not available.