### PR TITLE
Ensure Linux/Android arrays are filled entirely

### DIFF
--- a/secure-random/src/darwinMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/darwinMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
@@ -46,7 +46,7 @@ internal actual abstract class SecRandomDelegate private actual constructor() {
             // kSecRandomDefault is synonymous to NULL
             val errno: Int = SecRandomCopyBytes(kSecRandomDefault, size.toUInt().convert(), bytes.addressOf(0))
             if (errno != 0) {
-                throw SecRandomCopyException(errnoToString(errno))
+                throw errnoToSecRandomCopyException(errno)
             }
         }
     }

--- a/secure-random/src/darwinMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/darwinMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
@@ -18,8 +18,8 @@
 package io.matthewnelson.secure.random.internal
 
 import io.matthewnelson.secure.random.SecRandomCopyException
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.Pinned
+import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.UnsafeNumber
 import kotlinx.cinterop.convert
 import platform.Security.SecRandomCopyBytes
@@ -31,7 +31,7 @@ import platform.Security.kSecRandomDefault
 internal actual abstract class SecRandomDelegate private actual constructor() {
 
     @Throws(SecRandomCopyException::class)
-    internal actual abstract fun nextBytesCopyTo(size: Int, ptrBytes: CPointer<ByteVar>)
+    internal actual abstract fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int)
 
     internal actual companion object {
 
@@ -42,9 +42,9 @@ internal actual abstract class SecRandomDelegate private actual constructor() {
 
         @OptIn(UnsafeNumber::class)
         @Throws(SecRandomCopyException::class)
-        override fun nextBytesCopyTo(size: Int, ptrBytes: CPointer<ByteVar>) {
+        override fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int) {
             // kSecRandomDefault is synonymous to NULL
-            val errno: Int = SecRandomCopyBytes(kSecRandomDefault, size.toUInt().convert(), ptrBytes)
+            val errno: Int = SecRandomCopyBytes(kSecRandomDefault, size.toUInt().convert(), bytes.addressOf(0))
             if (errno != 0) {
                 throw SecRandomCopyException(errnoToString(errno))
             }

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/-LinuxAndroidPlatform.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/-LinuxAndroidPlatform.kt
@@ -16,10 +16,30 @@
 package io.matthewnelson.secure.random.internal
 
 import io.matthewnelson.secure.random.SecRandomCopyException
-import kotlinx.cinterop.toKStringFromUtf8
-import platform.posix.strerror
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.Pinned
+import kotlinx.cinterop.addressOf
+import platform.posix.EINTR
+import platform.posix.errno
 
-internal fun errnoToSecRandomCopyException(errno: Int): SecRandomCopyException {
-    val message = strerror(errno)?.toKStringFromUtf8() ?: "errno: $errno"
-    return SecRandomCopyException(message)
+internal fun Pinned<ByteArray>.fillCompletely(
+    size: Int,
+    block: (ptr: CPointer<ByteVar>, length: Int) -> Int
+) {
+    var index = 0
+    while (index < size) {
+
+        val remainder = size - index
+        val result = block.invoke(addressOf(index), remainder)
+
+        if (result < 0) {
+            when (val err = errno) {
+                EINTR -> continue // Retry
+                else -> throw errnoToSecRandomCopyException(err)
+            }
+        } else {
+            index = result
+        }
+    }
 }

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/GetRandom.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/GetRandom.kt
@@ -18,10 +18,7 @@
 package io.matthewnelson.secure.random.internal
 
 import io.matthewnelson.secure.random.SecRandomCopyException
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CPointer
-import kotlinx.cinterop.UnsafeNumber
-import kotlinx.cinterop.convert
+import kotlinx.cinterop.*
 import platform.posix.*
 
 /**
@@ -69,8 +66,8 @@ internal class GetRandom private constructor(): SecRandomPoller() {
      * */
     @OptIn(UnsafeNumber::class)
     @Throws(SecRandomCopyException::class)
-    internal fun getrandom(buf: CPointer<ByteVar>, buflen: Int) {
-        val result = getrandom(buf, buflen.toULong().convert(), NO_FLAGS)
+    internal fun getrandom(buf: Pinned<ByteArray>, buflen: Int) {
+        val result = getrandom(buf.addressOf(0), buflen.toULong().convert(), NO_FLAGS)
         if (result < 0) throw SecRandomCopyException(errnoToString(errno))
     }
 

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/GetRandom.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/GetRandom.kt
@@ -67,8 +67,9 @@ internal class GetRandom private constructor(): SecRandomPoller() {
     @OptIn(UnsafeNumber::class)
     @Throws(SecRandomCopyException::class)
     internal fun getrandom(buf: Pinned<ByteArray>, buflen: Int) {
-        val result = getrandom(buf.addressOf(0), buflen.toULong().convert(), NO_FLAGS)
-        if (result < 0) throw SecRandomCopyException(errnoToString(errno))
+        buf.fillCompletely(buflen) { ptr, len ->
+            getrandom(ptr, len.toULong().convert(), NO_FLAGS)
+        }
     }
 
     @OptIn(UnsafeNumber::class)

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
@@ -16,13 +16,12 @@
 package io.matthewnelson.secure.random.internal
 
 import io.matthewnelson.secure.random.SecRandomCopyException
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.Pinned
 
 internal actual abstract class SecRandomDelegate private actual constructor() {
 
     @Throws(SecRandomCopyException::class)
-    internal actual abstract fun nextBytesCopyTo(size: Int, ptrBytes: CPointer<ByteVar>)
+    internal actual abstract fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int)
 
     internal actual companion object {
 
@@ -38,16 +37,16 @@ internal actual abstract class SecRandomDelegate private actual constructor() {
     private object SecRandomDelegateGetRandom: SecRandomDelegate() {
 
         @Throws(SecRandomCopyException::class)
-        override fun nextBytesCopyTo(size: Int, ptrBytes: CPointer<ByteVar>) {
-            GetRandom.instance.getrandom(ptrBytes, size)
+        override fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int) {
+            GetRandom.instance.getrandom(bytes, size)
         }
     }
 
     internal object SecRandomDelegateURandom: SecRandomDelegate() {
 
         @Throws(SecRandomCopyException::class)
-        override fun nextBytesCopyTo(size: Int, ptrBytes: CPointer<ByteVar>) {
-            URandom.instance.readBytesTo(ptrBytes, size)
+        override fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int) {
+            URandom.instance.readBytesTo(bytes, size)
         }
     }
 }

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/URandom.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/URandom.kt
@@ -33,12 +33,12 @@ internal class URandom private constructor(): SecRandomPoller() {
     private val lock = Lock()
 
     @Throws(SecRandomCopyException::class)
-    internal fun readBytesTo(buf: CPointer<ByteVar>, buflen: Int) {
+    internal fun readBytesTo(buf: Pinned<ByteArray>, buflen: Int) {
         ensureSeeded()
         lock.withLock {
             @OptIn(UnsafeNumber::class)
             withReadOnlyFD("/dev/urandom") { fd ->
-                val result = read(fd, buf, buflen.toULong().convert())
+                val result = read(fd, buf.addressOf(0), buflen.toULong().convert())
                 if (result < 0) throw SecRandomCopyException(errnoToString(errno))
             }
         }

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/URandom.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/URandom.kt
@@ -38,8 +38,9 @@ internal class URandom private constructor(): SecRandomPoller() {
         lock.withLock {
             @OptIn(UnsafeNumber::class)
             withReadOnlyFD("/dev/urandom") { fd ->
-                val result = read(fd, buf.addressOf(0), buflen.toULong().convert())
-                if (result < 0) throw SecRandomCopyException(errnoToString(errno))
+                buf.fillCompletely(buflen) { ptr, length ->
+                    read(fd, ptr, length.toULong().convert()).convert()
+                }
             }
         }
     }
@@ -68,7 +69,7 @@ internal class URandom private constructor(): SecRandomPoller() {
                         when (val err = errno) {
                             EINTR,
                             EAGAIN -> continue
-                            else -> throw SecRandomCopyException(errnoToString(err))
+                            else -> throw errnoToSecRandomCopyException(err)
                         }
                     }
                 }
@@ -80,7 +81,7 @@ internal class URandom private constructor(): SecRandomPoller() {
 
     private fun withReadOnlyFD(path: String, block: (fd: Int) -> Unit) {
         val fd = open(path, O_RDONLY, null)
-        if (fd == -1) throw SecRandomCopyException(errnoToString(errno))
+        if (fd == -1) throw errnoToSecRandomCopyException(errno)
 
         try {
             block.invoke(fd)

--- a/secure-random/src/mingwMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/mingwMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
@@ -16,8 +16,8 @@
 package io.matthewnelson.secure.random.internal
 
 import io.matthewnelson.secure.random.SecRandomCopyException
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.Pinned
+import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.reinterpret
 import platform.windows.BCRYPT_USE_SYSTEM_PREFERRED_RNG
@@ -31,7 +31,7 @@ import platform.windows.STATUS_INVALID_PARAMETER
 internal actual abstract class SecRandomDelegate private actual constructor() {
 
     @Throws(SecRandomCopyException::class)
-    internal actual abstract fun nextBytesCopyTo(size: Int, ptrBytes: CPointer<ByteVar>)
+    internal actual abstract fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int)
 
     internal actual companion object {
 
@@ -44,10 +44,10 @@ internal actual abstract class SecRandomDelegate private actual constructor() {
     private object SecRandomDelegateMingwVistaSP2: SecRandomDelegate() {
 
         @Throws(SecRandomCopyException::class)
-        override fun nextBytesCopyTo(size: Int, ptrBytes: CPointer<ByteVar>) {
+        override fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int) {
             val status = BCryptGenRandom(
                 null,
-                ptrBytes.reinterpret(),
+                bytes.addressOf(0).reinterpret(),
                 size.toULong().convert(),
                 BCRYPT_USE_SYSTEM_PREFERRED_RNG,
             ).toUInt()

--- a/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/SecureRandom.kt
+++ b/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/SecureRandom.kt
@@ -17,7 +17,6 @@ package io.matthewnelson.secure.random
 
 import io.matthewnelson.secure.random.internal.commonNextBytesOf
 import io.matthewnelson.secure.random.internal.SecRandomDelegate
-import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.usePinned
 
@@ -53,7 +52,7 @@ public actual class SecureRandom {
         bytes.ifNotNullOrEmpty {
             usePinned { pinned ->
                 memScoped {
-                    delegate.nextBytesCopyTo(size, pinned.addressOf(0))
+                    delegate.nextBytesCopyTo(pinned, size)
                 }
             }
         }

--- a/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/SecureRandom.kt
+++ b/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/SecureRandom.kt
@@ -17,7 +17,6 @@ package io.matthewnelson.secure.random
 
 import io.matthewnelson.secure.random.internal.commonNextBytesOf
 import io.matthewnelson.secure.random.internal.SecRandomDelegate
-import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.usePinned
 
 /**
@@ -29,7 +28,6 @@ public actual class SecureRandom {
 
     public actual constructor(): this(SecRandomDelegate.instance())
     internal constructor(delegate: SecRandomDelegate) { this.delegate = delegate }
-
 
     /**
      * Returns a [ByteArray] of size [count], filled with
@@ -51,9 +49,7 @@ public actual class SecureRandom {
     public actual fun nextBytesCopyTo(bytes: ByteArray?) {
         bytes.ifNotNullOrEmpty {
             usePinned { pinned ->
-                memScoped {
-                    delegate.nextBytesCopyTo(pinned, size)
-                }
+                delegate.nextBytesCopyTo(pinned, size)
             }
         }
     }

--- a/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
@@ -16,13 +16,12 @@
 package io.matthewnelson.secure.random.internal
 
 import io.matthewnelson.secure.random.SecRandomCopyException
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.Pinned
 
 internal expect abstract class SecRandomDelegate private constructor() {
 
     @Throws(SecRandomCopyException::class)
-    internal abstract fun nextBytesCopyTo(size: Int, ptrBytes: CPointer<ByteVar>)
+    internal abstract fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int)
 
     internal companion object {
 


### PR DESCRIPTION
Closes #31 

Adds an extension function to check the result of either `getrandom` or reading from `/dev/urandom` such that if the amount returned is less than the `ByteArray.size`, then it calls the function again until it is completely filled.