### PR TITLE
Remove `SecRandomDelegate.instance`

### DIFF
--- a/secure-random/src/darwinMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/darwinMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
@@ -33,16 +33,11 @@ internal actual abstract class SecRandomDelegate private actual constructor() {
     @Throws(SecRandomCopyException::class)
     internal actual abstract fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int)
 
-    internal actual companion object {
-
-        internal actual fun instance(): SecRandomDelegate = SecRandomDelegateDarwin
-    }
-
-    private object SecRandomDelegateDarwin: SecRandomDelegate() {
+    internal actual companion object: SecRandomDelegate() {
 
         @OptIn(UnsafeNumber::class)
         @Throws(SecRandomCopyException::class)
-        override fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int) {
+        actual override fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int) {
             // kSecRandomDefault is synonymous to NULL
             val errno: Int = SecRandomCopyBytes(kSecRandomDefault, size.toUInt().convert(), bytes.addressOf(0))
             if (errno != 0) {

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
@@ -23,22 +23,15 @@ internal actual abstract class SecRandomDelegate private actual constructor() {
     @Throws(SecRandomCopyException::class)
     internal actual abstract fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int)
 
-    internal actual companion object {
-
-        actual fun instance(): SecRandomDelegate {
-            return if (GetRandom.instance.isAvailable()) {
-                SecRandomDelegateGetRandom
-            } else {
-                SecRandomDelegateURandom
-            }
-        }
-    }
-
-    private object SecRandomDelegateGetRandom: SecRandomDelegate() {
+    internal actual companion object: SecRandomDelegate() {
 
         @Throws(SecRandomCopyException::class)
-        override fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int) {
-            GetRandom.instance.getrandom(bytes, size)
+        actual override fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int) {
+            if (GetRandom.instance.isAvailable()) {
+                GetRandom.instance.getrandom(bytes, size)
+            } else {
+                SecRandomDelegateURandom.nextBytesCopyTo(bytes, size)
+            }
         }
     }
 

--- a/secure-random/src/mingwMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/mingwMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
@@ -33,18 +33,10 @@ internal actual abstract class SecRandomDelegate private actual constructor() {
     @Throws(SecRandomCopyException::class)
     internal actual abstract fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int)
 
-    internal actual companion object {
-
-        internal actual fun instance(): SecRandomDelegate {
-            // TODO: Add fallbacks for pre Vista SP2 (Issue #8)
-            return SecRandomDelegateMingwVistaSP2
-        }
-    }
-
-    private object SecRandomDelegateMingwVistaSP2: SecRandomDelegate() {
+    internal actual companion object: SecRandomDelegate() {
 
         @Throws(SecRandomCopyException::class)
-        override fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int) {
+        actual override fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int) {
             val status = BCryptGenRandom(
                 null,
                 bytes.addressOf(0).reinterpret(),

--- a/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/SecureRandom.kt
+++ b/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/SecureRandom.kt
@@ -26,7 +26,7 @@ public actual class SecureRandom {
 
     private val delegate: SecRandomDelegate
 
-    public actual constructor(): this(SecRandomDelegate.instance())
+    public actual constructor(): this(SecRandomDelegate)
     internal constructor(delegate: SecRandomDelegate) { this.delegate = delegate }
 
     /**

--- a/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/nativeMain/kotlin/io/matthewnelson/secure/random/internal/SecRandomDelegate.kt
@@ -23,8 +23,8 @@ internal expect abstract class SecRandomDelegate private constructor() {
     @Throws(SecRandomCopyException::class)
     internal abstract fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int)
 
-    internal companion object {
+    internal companion object: SecRandomDelegate {
 
-        internal fun instance(): SecRandomDelegate
+        override fun nextBytesCopyTo(bytes: Pinned<ByteArray>, size: Int)
     }
 }


### PR DESCRIPTION
Closes #33 

`SecRandomDelegate.Companion` is now the "default" that is used when `SecureRandom()` is called. Alternative "fall back" implementations (such as `SecRandomDefaultURandom`) can still be constructor injected internally for testing purposes.